### PR TITLE
Fix cursor radius update

### DIFF
--- a/sand-painting/sand-painting-script.js
+++ b/sand-painting/sand-painting-script.js
@@ -186,13 +186,8 @@ function setMode(isEraser) {
 
 function updateCurrentRadius() {
     currentRadius = isEraserMode ? eraserRadius : brushRadius;
-    updateCursorCircle(currentRadius);
-}
-
-function updateCursorCircle(radius) {
-    const cursorCircle = document.getElementById("cursor-circle");
-    cursorCircle.style.width = `${radius * 2}px`;
-    cursorCircle.style.height = `${radius * 2}px`;
+    // update circle using the current mouse coordinates
+    updateCursorCircle(mouse.x, mouse.y, currentRadius);
 }
 
 function showConfirmationDialog() {


### PR DESCRIPTION
## Summary
- fix wrong `updateCursorCircle` call when changing tool radius in sand painting
- drop unused single-argument function to avoid conflicts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885bbc0576083298eb4c73659e7c23d